### PR TITLE
Add config for Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "prettier": {
+    "printWidth": 120
+  }
 }


### PR DESCRIPTION
Prettier reads some of the config options from `.editorconfig` too.

I set the maximum line length to 120. I think the default is 80. What would be a good length?

Also note that this doesn't add the Prettier package to be run automatically or anything. This only effects those who use Prettier in their editor or even command line.