### PR TITLE
Remove usage of dangerouslySetInnerHTML from subs

### DIFF
--- a/process_subs.js
+++ b/process_subs.js
@@ -33,9 +33,10 @@ async function do_it() {
         time_match[4] * 1;
       let text = rows.slice(2);
       let processed_text = []
-      for (row of text) {
-        row = row.replace("<i>", "")
-        row = row.replace("</i>", "")
+      for (let row of text) {
+        // Remove everything that looks like an HTML tag. That means all `<` + `>` pairs and everything between them.
+        row = row.replace(/<[^>]*>/gm, '');
+
         if (row.substring(0, 2) === "- ") {
           row = row.substring(2);
         }

--- a/src/Subs/SubsDisplay.js
+++ b/src/Subs/SubsDisplay.js
@@ -36,7 +36,7 @@ export default function SubsDisplay({
         </h3>
       ) : null}
       {Array.from(groupedChunks.values()).map(group => (
-        <div>
+        <div key={`${group[0].season}_${group[0].episode}`}>
           <h3 className="episode-title">
             {group[0].episode === 0 ? `${2010 + parseInt(group[0].season)} Christmas Special` : `S${group[0].season}E${group[0].episode}`}{" "}
             {query ? <small>({group.length} hit{group.length !== 1 ? "s" : ""})</small> : null}
@@ -51,7 +51,7 @@ export default function SubsDisplay({
               highlight[2] === chunk.starttime;
 
             return (
-              <>
+              <React.Fragment key={`${chunk.season}_${chunk.episode}_${chunk.starttime}`}>
                 <p className="starttime" ref={isHighlighted ? highlightRef : null}>
                   {formatTimecode(chunk.starttime)}
                 </p>
@@ -63,7 +63,7 @@ export default function SubsDisplay({
                     onClick(chunk.season, chunk.episode, chunk.starttime)
                   }
                 ></p>
-              </>
+              </React.Fragment>
             );
           })}
         </div>

--- a/src/Subs/SubsDisplay.js
+++ b/src/Subs/SubsDisplay.js
@@ -16,7 +16,7 @@ export default function SubsDisplay({
 
   const q = query.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
   // TODO: Display chunks. May get query, which should be highlighted if exists
-  const re = new RegExp(q, "gi");
+  const re = new RegExp(`(${q})`, "gi");
 
   const groupedChunks = new Map();
 
@@ -42,7 +42,10 @@ export default function SubsDisplay({
             {query ? <small>({group.length} hit{group.length !== 1 ? "s" : ""})</small> : null}
           </h3>
           {group.map(chunk => {
-            const text = chunk.text.replace(re, `<em>$&</em>`);
+            const parts = chunk.text.split(re);
+            for (let i = 1; i < parts.length; i += 2) {
+              parts[i] = <em key={i}>{parts[i]}</em>;
+            }
 
             const isHighlighted =
               highlight &&
@@ -57,12 +60,11 @@ export default function SubsDisplay({
                 </p>
                 <p
                   className="subs-text"
-                  dangerouslySetInnerHTML={{ __html: text }}
                   onClick={() =>
                     onClick &&
                     onClick(chunk.season, chunk.episode, chunk.starttime)
                   }
-                ></p>
+                >{parts}</p>
               </React.Fragment>
             );
           })}


### PR DESCRIPTION
This removes the usage of `dangerouslySetInnerHTML` when displaying subs with highlights. Instead we create React elements dynamically.

I learned something new about JavaScript, which made this possible. From [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split):

> If `separator` is a regular expression that contains capturing parentheses (), matched results are included in the array.